### PR TITLE
Add a command line option to set the random seed before generating random Fourier featuers

### DIFF
--- a/pummeler/cli.py
+++ b/pummeler/cli.py
@@ -77,6 +77,9 @@ def main():
                      help='Gaussian kernel bandwidth. Default: choose the '
                           'median distance among the random sample saved in '
                           'the stats file.')
+    emb.add_argument('--seed', type=int, default=-1,
+                     help='Random seed for generating random frequencies. '
+                          'Default: none')
     emb.add_argument('--skip-feats', nargs='+', metavar='FEAT_NAME',
                      help="Don't include some features in the embedding.")
 
@@ -111,7 +114,7 @@ def do_featurize(args, parser):
     else:
         emb_lin, emb_rff, freqs, bandwidth, feature_names = get_embeddings(
             files, stats=stats, n_freqs=args.n_freqs, bandwidth=args.bandwidth,
-            skip_feats=args.skip_feats, chunksize=args.chunksize)
+            skip_feats=args.skip_feats, seed=args.seed, chunksize=args.chunksize)
         np.savez(args.outfile,
                  emb_lin=emb_lin, emb_rff=emb_rff,
                  freqs=freqs, bandwidth=bandwidth,

--- a/pummeler/cli.py
+++ b/pummeler/cli.py
@@ -77,7 +77,7 @@ def main():
                      help='Gaussian kernel bandwidth. Default: choose the '
                           'median distance among the random sample saved in '
                           'the stats file.')
-    emb.add_argument('--seed', type=int, default=-1,
+    emb.add_argument('--seed', type=int, default=None,
                      help='Random seed for generating random frequencies. '
                           'Default: none')
     emb.add_argument('--skip-feats', nargs='+', metavar='FEAT_NAME',

--- a/pummeler/featurize.py
+++ b/pummeler/featurize.py
@@ -108,7 +108,7 @@ def rff_embedding(feats, wts, freqs, out=None):
     return out
 
 
-def pick_rff_freqs(n_freqs, bandwidth, n_feats=None, 
+def pick_rff_freqs(n_freqs, bandwidth, seed=None, n_feats=None,
                    stats=None, skip_feats=None):
     '''
     Sets up sampling with random Fourier features corresponding to a Gaussian
@@ -118,6 +118,8 @@ def pick_rff_freqs(n_freqs, bandwidth, n_feats=None,
     '''
     if n_feats is None:
         n_feats = _num_feats(stats, skip_feats=skip_feats)
+    if not seed is None:
+        np.random.seed(seed)
     return np.random.normal(0, 1 / bandwidth, size=(n_feats, n_freqs))
 
 
@@ -135,7 +137,7 @@ def pick_gaussian_bandwidth(stats, skip_feats=None):
 ################################################################################
 
 def get_embeddings(files, stats, n_freqs=2048, freqs=None, bandwidth=None,
-                   chunksize=2**13, skip_rbf=False, skip_feats=None):
+                   chunksize=2**13, skip_rbf=False, skip_feats=None, seed=None):
     skip_feats = set() if skip_feats is None else set(skip_feats)
     n_feats = _num_feats(stats, skip_feats=skip_feats)
     feat_names = None
@@ -148,7 +150,7 @@ def get_embeddings(files, stats, n_freqs=2048, freqs=None, bandwidth=None,
                 bandwidth = pick_gaussian_bandwidth(
                         stats, skip_feats=skip_feats)
                 print("picked {}".format(bandwidth), file=sys.stderr)
-            freqs = pick_rff_freqs(n_freqs, bandwidth, n_feats=n_feats)
+            freqs = pick_rff_freqs(n_freqs, bandwidth, seed, n_feats=n_feats)
         else:
             n_freqs = freqs.shape[1]
 


### PR DESCRIPTION
If featurize is called repeatedly (as it will be for, e.g. demographic subgroups or generating state-level aggregates after already having done region-level) then each time we want to use the same random frequencies for the random Fourier features. This adds an option --seed to do just that.
